### PR TITLE
Patch and ignore StatsApplianceList.query to unblock 6.0 sdpctl upgrade 

### DIFF
--- a/api/v19/openapi/model_stats_appliances_list.go
+++ b/api/v19/openapi/model_stats_appliances_list.go
@@ -32,9 +32,6 @@ type StatsAppliancesList struct {
 	Descending *bool `json:"descending,omitempty"`
 	// The queries applied to the list.
 	Queries []string `json:"queries,omitempty"`
-	// The first query applied to the list. Deprecated as of 6.0. Use queries instead.
-	// Deprecated
-	Query *string `json:"query,omitempty"`
 	// The filters applied to the list.
 	FilterBy []FilterBy `json:"filterBy,omitempty"`
 	// The number of active Appliances with the Controller role enabled.
@@ -293,41 +290,6 @@ func (o *StatsAppliancesList) HasQueries() bool {
 // SetQueries gets a reference to the given []string and assigns it to the Queries field.
 func (o *StatsAppliancesList) SetQueries(v []string) {
 	o.Queries = v
-}
-
-// GetQuery returns the Query field value if set, zero value otherwise.
-// Deprecated
-func (o *StatsAppliancesList) GetQuery() string {
-	if o == nil || o.Query == nil {
-		var ret string
-		return ret
-	}
-	return *o.Query
-}
-
-// GetQueryOk returns a tuple with the Query field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-// Deprecated
-func (o *StatsAppliancesList) GetQueryOk() (*string, bool) {
-	if o == nil || o.Query == nil {
-		return nil, false
-	}
-	return o.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (o *StatsAppliancesList) HasQuery() bool {
-	if o != nil && o.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery gets a reference to the given string and assigns it to the Query field.
-// Deprecated
-func (o *StatsAppliancesList) SetQuery(v string) {
-	o.Query = &v
 }
 
 // GetFilterBy returns the FilterBy field value if set, zero value otherwise.
@@ -640,9 +602,6 @@ func (o StatsAppliancesList) MarshalJSON() ([]byte, error) {
 	}
 	if o.Queries != nil {
 		toSerialize["queries"] = o.Queries
-	}
-	if o.Query != nil {
-		toSerialize["query"] = o.Query
 	}
 	if o.FilterBy != nil {
 		toSerialize["filterBy"] = o.FilterBy

--- a/api/v19/openapi/model_stats_appliances_list_all_of.go
+++ b/api/v19/openapi/model_stats_appliances_list_all_of.go
@@ -19,9 +19,6 @@ import (
 type StatsAppliancesListAllOf struct {
 	// The queries applied to the list.
 	Queries []string `json:"queries,omitempty"`
-	// The first query applied to the list. Deprecated as of 6.0. Use queries instead.
-	// Deprecated
-	Query *string `json:"query,omitempty"`
 	// The filters applied to the list.
 	FilterBy []FilterBy `json:"filterBy,omitempty"`
 	// The number of active Appliances with the Controller role enabled.
@@ -88,41 +85,6 @@ func (o *StatsAppliancesListAllOf) HasQueries() bool {
 // SetQueries gets a reference to the given []string and assigns it to the Queries field.
 func (o *StatsAppliancesListAllOf) SetQueries(v []string) {
 	o.Queries = v
-}
-
-// GetQuery returns the Query field value if set, zero value otherwise.
-// Deprecated
-func (o *StatsAppliancesListAllOf) GetQuery() string {
-	if o == nil || o.Query == nil {
-		var ret string
-		return ret
-	}
-	return *o.Query
-}
-
-// GetQueryOk returns a tuple with the Query field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-// Deprecated
-func (o *StatsAppliancesListAllOf) GetQueryOk() (*string, bool) {
-	if o == nil || o.Query == nil {
-		return nil, false
-	}
-	return o.Query, true
-}
-
-// HasQuery returns a boolean if a field has been set.
-func (o *StatsAppliancesListAllOf) HasQuery() bool {
-	if o != nil && o.Query != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetQuery gets a reference to the given string and assigns it to the Query field.
-// Deprecated
-func (o *StatsAppliancesListAllOf) SetQuery(v string) {
-	o.Query = &v
 }
 
 // GetFilterBy returns the FilterBy field value if set, zero value otherwise.
@@ -417,9 +379,6 @@ func (o StatsAppliancesListAllOf) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Queries != nil {
 		toSerialize["queries"] = o.Queries
-	}
-	if o.Query != nil {
-		toSerialize["query"] = o.Query
 	}
 	if o.FilterBy != nil {
 		toSerialize["filterBy"] = o.FilterBy

--- a/spec/spec-patches/v19/dashboard_statsappliancelist_query.patch
+++ b/spec/spec-patches/v19/dashboard_statsappliancelist_query.patch
@@ -1,0 +1,15 @@
+diff --git a/dashboard.yml b/dashboard.yml
+index e9b25c016..73d77860d 100644
+--- a/dashboard.yml
++++ b/dashboard.yml
+@@ -526,10 +526,6 @@ definitions:
+             description: The queries applied to the list.
+             items:
+               type: string
+-          query:
+-            type: string
+-            deprecated: true
+-            description: The first query applied to the list. Deprecated as of 6.0. Use queries instead.
+           filterBy:
+             type: array
+             description: The filters applied to the list.


### PR DESCRIPTION
6.0 returns a List<string> for `query`'s return type, but the API spec states it returns string. 

Per discussion with @natan-abolafya, instead of backporting the fix (and requiring customer to move to new 6.0.x version), it was easier to simply patch the go api client and ignore the field when deserializing it. 